### PR TITLE
add adversarial test for non-standardized prototype labels

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,36 @@ def get_test_crystal_structures(
             indices_to_test = [0]
         test_crystal_structures += [query_result[i] for i in indices_to_test]
 
+    # This is an adversarial example, because the Wyckoff set eh is
+    # non-contiguous, and the alphabetically minimal label for this
+    # structure becomes A2B11_cP39_200_f_begik, so the position of
+    # the equivalent Wyckoff position moves in the string. This
+    # tests the bugfix to the call to
+    # get_equivalent_atom_sets_from_prototype_and_atom_map()
+    # in AFLOW.solve_for_params_of_known_prototype(), where
+    # formerly the ASSUMED prototype label was being given
+    # instead of the PROVIDED one.
+    test_crystal_structures.append(
+        {
+            "prototype-label": {"source-value": "A2B11_cP39_200_f_aghij"},
+            "stoichiometric-species": {"source-value": ["Mg", "Zn"]},
+            "a": {
+                "source-value": 8.447753605464722,
+                "source-unit": "angstrom",
+            },
+            "parameter-values": {
+                "source-value": [
+                    0.19825371336523778,
+                    0.6620338892287034,
+                    0.2702445039150718,
+                    0.7180083017782286,
+                    0.8419916396901792,
+                    0.737676629736925,
+                ]
+            },
+        }
+    )
+
     with open(QUERY_DUMP, "w") as f:
         json.dump(test_crystal_structures, f)
 


### PR DESCRIPTION
Closes #2, fixed in AFLOW 4.1, this test checks that it is true