### PR TITLE
Add debugging option to not archive aux files

### DIFF
--- a/kim_tools/__init__.py
+++ b/kim_tools/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.11"
+__version__ = "0.4.12"
 
 from .aflow_util import *
 from .aflow_util import __all__ as aflow_all

--- a/kim_tools/test_driver/core.py
+++ b/kim_tools/test_driver/core.py
@@ -772,7 +772,9 @@ class KIMTestDriver(ABC):
         """
         raise NotImplementedError("Subclasses must implement the _calculate method.")
 
-    def __call__(self, material: Any = None, **kwargs) -> List[Dict]:
+    def __call__(
+        self, material: Any = None, archive_aux_files: bool = True, **kwargs
+    ) -> List[Dict]:
         """
 
         Main operation of a Test Driver:
@@ -788,6 +790,10 @@ class KIMTestDriver(ABC):
             material:
                 Placeholder object for arguments describing the material to run
                 the Test Driver on
+            archive_aux_files:
+                By default, auxiliary computational files that are not
+                reported in a property are compressed into a .txz file.
+                Set this to False to turn this off for debugging.
 
         Returns:
             The property instances calculated during the current run
@@ -806,8 +812,15 @@ class KIMTestDriver(ABC):
             # implemented by each individual Test Driver
             self._calculate(**kwargs)
         finally:
-            # Postprocess output directory for this invocation
-            self._archive_aux_files()
+            if archive_aux_files:
+                # Postprocess output directory for this invocation
+                self._archive_aux_files()
+            else:
+                print(
+                    "WARNING: Not archiving auxiliary files. This can cause conflicts "
+                    "if an instance of this class is called multiple times. "
+                    "Use with caution for debugging only."
+                )
 
         # The current invocation returns a Python list of dictionaries containing all
         # properties computed during this run

--- a/tests/test_test_driver.py
+++ b/tests/test_test_driver.py
@@ -447,6 +447,12 @@ def test_file_writing():
             except KIMTestDriverError:
                 assert True
 
+            # Test non-archiving of aux files (debug feature)
+            td2(archive_aux_files=False)
+            assert os.path.isfile("output/foo")
+            assert os.path.isfile("output/bar/bar")
+            assert os.path.isfile("output/baz/baz")
+
     finally:
         os.chdir(oldcwd)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version bumped to 0.4.12

* **New Features**
  * Added optional parameter to control archiving of auxiliary output files in the test driver; archiving is enabled by default. When disabled, auxiliary files remain unarchived to prevent conflicts when running multiple test driver instances sequentially.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openkim/kim-tools/pull/35)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->