### PR TITLE
update .kim_model_name return type hint, and test it

### DIFF
--- a/kim_tools/__init__.py
+++ b/kim_tools/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.11"
+__version__ = "0.4.12"
 
 from .aflow_util import *
 from .aflow_util import __all__ as aflow_all

--- a/kim_tools/test_driver/core.py
+++ b/kim_tools/test_driver/core.py
@@ -956,9 +956,13 @@ class KIMTestDriver(ABC):
         return get_supported_lammps_atom_style(self.kim_model_name)
 
     @property
-    def kim_model_name(self) -> Optional[str]:
+    def kim_model_name(self) -> str:
         """
-        Get the KIM model name, if present
+        Get the KIM model name
+
+        Raises:
+            KIMTestDriver.NonKIMModelError:
+                If the Test Driver is being run with a non-KIM calculator
         """
         if self.__kim_model_name is not None:
             return self.__kim_model_name

--- a/kim_tools/test_driver/core.py
+++ b/kim_tools/test_driver/core.py
@@ -772,9 +772,7 @@ class KIMTestDriver(ABC):
         """
         raise NotImplementedError("Subclasses must implement the _calculate method.")
 
-    def __call__(
-        self, material: Any = None, archive_aux_files: bool = True, **kwargs
-    ) -> List[Dict]:
+    def __call__(self, material: Any = None, **kwargs) -> List[Dict]:
         """
 
         Main operation of a Test Driver:
@@ -790,10 +788,6 @@ class KIMTestDriver(ABC):
             material:
                 Placeholder object for arguments describing the material to run
                 the Test Driver on
-            archive_aux_files:
-                By default, auxiliary computational files that are not
-                reported in a property are compressed into a .txz file.
-                Set this to False to turn this off for debugging.
 
         Returns:
             The property instances calculated during the current run
@@ -812,15 +806,8 @@ class KIMTestDriver(ABC):
             # implemented by each individual Test Driver
             self._calculate(**kwargs)
         finally:
-            if archive_aux_files:
-                # Postprocess output directory for this invocation
-                self._archive_aux_files()
-            else:
-                print(
-                    "WARNING: Not archiving auxiliary files. This can cause conflicts "
-                    "if an instance of this class is called multiple times. "
-                    "Use with caution for debugging only."
-                )
+            # Postprocess output directory for this invocation
+            self._archive_aux_files()
 
         # The current invocation returns a Python list of dictionaries containing all
         # properties computed during this run

--- a/kim_tools/test_driver/core.py
+++ b/kim_tools/test_driver/core.py
@@ -772,7 +772,9 @@ class KIMTestDriver(ABC):
         """
         raise NotImplementedError("Subclasses must implement the _calculate method.")
 
-    def __call__(self, material: Any = None, **kwargs) -> List[Dict]:
+    def __call__(
+        self, material: Any = None, archive_aux_files: bool = True, **kwargs
+    ) -> List[Dict]:
         """
 
         Main operation of a Test Driver:
@@ -788,6 +790,10 @@ class KIMTestDriver(ABC):
             material:
                 Placeholder object for arguments describing the material to run
                 the Test Driver on
+            archive_aux_files:
+                By default, auxiliary computational files that are not
+                reported in a property are compressed into a .txz file.
+                Set this to False to turn this off for debugging.
 
         Returns:
             The property instances calculated during the current run
@@ -806,8 +812,15 @@ class KIMTestDriver(ABC):
             # implemented by each individual Test Driver
             self._calculate(**kwargs)
         finally:
-            # Postprocess output directory for this invocation
-            self._archive_aux_files()
+            if archive_aux_files:
+                # Postprocess output directory for this invocation
+                self._archive_aux_files()
+            else:
+                print(
+                    "WARNING: Not archiving auxiliary files. This can cause conflicts "
+                    "if an instance of this class is called multiple times. "
+                    "Use with caution for debugging only."
+                )
 
         # The current invocation returns a Python list of dictionaries containing all
         # properties computed during this run

--- a/tests/test_test_driver.py
+++ b/tests/test_test_driver.py
@@ -521,5 +521,17 @@ def test_stress_and_pressure_variables():
     assert td._get_cell_cauchy_stress() == [-1, -1, -1, 0, 0, 0]
 
 
+def test_kim_model_name():
+    modelname = "LJ_ElliottAkerson_2015_Universal__MO_959249795837_003"
+    td = TestInitKIMTestDriver(modelname)
+    assert td.kim_model_name == modelname
+    td = TestInitKIMTestDriver(LennardJones())
+    try:
+        td.kim_model_name
+        assert False
+    except KIMTestDriver.NonKIMModelError:
+        assert True
+
+
 if __name__ == "__main__":
     test_atom_style()

--- a/tests/test_test_driver.py
+++ b/tests/test_test_driver.py
@@ -447,6 +447,12 @@ def test_file_writing():
             except KIMTestDriverError:
                 assert True
 
+            # Test non-archiving of aux files (debug feature)
+            td2(archive_aux_files=False)
+            assert os.path.isfile("output/foo")
+            assert os.path.isfile("output/bar/bar")
+            assert os.path.isfile("output/baz/baz")
+
     finally:
         os.chdir(oldcwd)
 

--- a/tests/test_test_driver.py
+++ b/tests/test_test_driver.py
@@ -447,12 +447,6 @@ def test_file_writing():
             except KIMTestDriverError:
                 assert True
 
-            # Test non-archiving of aux files (debug feature)
-            td2(archive_aux_files=False)
-            assert os.path.isfile("output/foo")
-            assert os.path.isfile("output/bar/bar")
-            assert os.path.isfile("output/baz/baz")
-
     finally:
         os.chdir(oldcwd)
 

--- a/tests/test_test_driver.py
+++ b/tests/test_test_driver.py
@@ -9,6 +9,7 @@ from tempfile import TemporaryDirectory
 import kim_edn
 import numpy as np
 import numpy.typing as npt
+import pytest
 from ase.atoms import Atoms
 from ase.build import bulk
 from ase.calculators.lj import LennardJones
@@ -395,11 +396,8 @@ def test_file_writing():
             with open("output/baz/nondotfile", "w") as f:
                 f.write("foo")
 
-            try:
+            with pytest.raises(KIMTestDriverError):
                 td()
-                assert False
-            except KIMTestDriverError:
-                assert True
 
             os.mkdir("output.0")
 
@@ -441,11 +439,8 @@ def test_file_writing():
 
             # Try calling the first Test Driver again. Should fail
             # due to a token mismatch.
-            try:
+            with pytest.raises(KIMTestDriverError):
                 td()
-                assert False
-            except KIMTestDriverError:
-                assert True
 
     finally:
         os.chdir(oldcwd)
@@ -475,26 +470,20 @@ def test_stress_and_pressure_variables():
     # Test incorrectly specifying both stress and pressure
 
     td = TestInitSingleCrystalTestDriver(LennardJones())
-    try:
+    with pytest.raises(KIMTestDriverError):
         td(
             structure,
             cell_cauchy_stress_eV_angstrom3=[0] * 6,
             pressure_eV_angstrom3=0,
         )
-        assert False
-    except KIMTestDriverError:
-        pass
 
     # Test incorrect length
     td = TestInitSingleCrystalTestDriver(LennardJones())
-    try:
+    with pytest.raises(KIMTestDriverError):
         td(
             structure,
             cell_cauchy_stress_eV_angstrom3=[0] * 5,
         )
-        assert False
-    except KIMTestDriverError:
-        pass
 
     # Test setting and retrieving stress
     td = TestInitSingleCrystalTestDriver(LennardJones())
@@ -504,11 +493,9 @@ def test_stress_and_pressure_variables():
     )
     assert np.allclose(td._get_cell_cauchy_stress(unit="GPa"), [160.21766] * 6)
     # Confirm that non-hydrostatic stress causes an error
-    try:
+    with pytest.raises(KIMTestDriverError):
         td._get_pressure()
-        assert False
-    except KIMTestDriverError:
-        pass
+
     # Get the pressure anyway
     assert td._get_pressure(enforce_hydrostatic=False) == -1
 
@@ -526,11 +513,8 @@ def test_kim_model_name():
     td = TestInitKIMTestDriver(modelname)
     assert td.kim_model_name == modelname
     td = TestInitKIMTestDriver(LennardJones())
-    try:
+    with pytest.raises(KIMTestDriver.NonKIMModelError):
         td.kim_model_name
-        assert False
-    except KIMTestDriver.NonKIMModelError:
-        assert True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Version Update**
  * Released v0.4.12

* **Bug Fixes**
  * Model name property refined to be non-optional for stronger type safety and consistency.

* **Documentation**
  * Clarified documentation to explicitly state when an error is raised for incompatible calculators.

* **Tests**
  * Added tests (using pytest) to validate model name behavior and error handling across calculator types

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openkim/kim-tools/pull/36)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->