### PR TITLE
Change how `reduce_and_avg` checks distances

### DIFF
--- a/kim_tools/__init__.py
+++ b/kim_tools/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.12"
+__version__ = "0.4.13"
 
 from .aflow_util import *
 from .aflow_util import __all__ as aflow_all

--- a/kim_tools/symmetry_util/core.py
+++ b/kim_tools/symmetry_util/core.py
@@ -639,7 +639,9 @@ def transform_atoms(atoms: Atoms, op: Dict) -> Atoms:
     return atoms_transformed
 
 
-def reduce_and_avg(atoms: Atoms, repeat: Tuple[int, int, int]) -> Atoms:
+def reduce_and_avg(
+    atoms: Atoms, repeat: Tuple[int, int, int], tol: Optional[float] = None
+) -> Atoms:
     """
     TODO: Upgrade :func:`change_of_basis_atoms` to provide the distances
     array, obviating this function
@@ -656,15 +658,19 @@ def reduce_and_avg(atoms: Atoms, repeat: Tuple[int, int, int]) -> Atoms:
         repeat:
             The number of repeats of each unit cell vector in the
             provided supercell
+        tol:
+            Tolerance for translational periodicity. If an atom in the original
+            supercell is found to be greater than this distance away from its location
+            as prescribed by the reduced unit cell, raise an error.
+            Default is 0.01*NN distance.
 
     Returns:
         The reduced unit cell
 
     Raises:
         PeriodExtensionException:
-            If two atoms that should be identical by translational symmetry
-            are further than 0.01*(smallest NN distance) apart when
-            reduced to the unit cell
+            If an atom in the original supercell is found to be greater than `tol`
+            away from its location as prescribed by the reduced unit cell
     """
     new_atoms = atoms.copy()
 
@@ -712,31 +718,30 @@ def reduce_and_avg(atoms: Atoms, repeat: Tuple[int, int, int]) -> Atoms:
             position_i = positions[i]
         # Average
         avg_positions_in_prim_cell[reference_atom_index] += position_i / M
+        # Save for checking for period-extension phase transition
         positions_in_prim_cell[i] = position_i
 
     new_atoms.set_positions(avg_positions_in_prim_cell)
 
-    # Check that all atoms are within tolerance of their translational images
-    cutoff = get_smallest_nn_dist(new_atoms) * 0.01
-    logger.info(f"Cutoff for period extension test is {cutoff}")
+    if tol is None:
+        tol = get_smallest_nn_dist(atoms) * 0.01
+
+    # Check that all atoms are within tolerance of their reduced position
+    logger.info(f"Cutoff for period extension test is {tol}")
     for i in range(original_number_atoms):
         positions_of_all_images_of_atom_i = [
             positions_in_prim_cell[j * original_number_atoms + i] for j in range(M)
         ]
         _, r = get_distances(
             positions_of_all_images_of_atom_i,
+            avg_positions_in_prim_cell[i],
             cell=new_atoms.get_cell(),
             pbc=True,
         )
-        # Checking full MxM matrix, could probably speed up by
-        # checking upper triangle only. Could also save memory
-        # by looping over individual distances instead of
-        # checking the max of a giant matrix
-        assert r.shape == (M, M)
-        if r.max() > cutoff:
+        if r.max() > tol:
             raise PeriodExtensionException(
                 f"Found image of atom {i} is at a distance {r.max()}, "
-                f"outside of tolerance {cutoff}."
+                f"outside of tolerance {tol}."
             )
     return new_atoms
 

--- a/kim_tools/symmetry_util/core.py
+++ b/kim_tools/symmetry_util/core.py
@@ -671,6 +671,8 @@ def reduce_and_avg(
         PeriodExtensionException:
             If an atom in the original supercell is found to be greater than `tol`
             away from its location as prescribed by the reduced unit cell
+        ValueError:
+            If tol is not a positive number
     """
     new_atoms = atoms.copy()
 
@@ -725,6 +727,9 @@ def reduce_and_avg(
 
     if tol is None:
         tol = get_smallest_nn_dist(atoms) * 0.01
+    else:
+        if not tol > 0:
+            raise ValueError(f"Provided tolerance {tol} is not a positive number")
 
     # Check that all atoms are within tolerance of their reduced position
     logger.info(f"Cutoff for period extension test is {tol}")

--- a/tests/test_symmetry_util.py
+++ b/tests/test_symmetry_util.py
@@ -3,6 +3,7 @@
 import math
 
 import numpy as np
+import pytest
 from ase.build import bulk
 from ase.calculators.kim.kim import KIM
 from ase.geometry import get_duplicate_atoms
@@ -84,6 +85,9 @@ def test_test_reduced_distances():
             assert not has_period_extension
         except PeriodExtensionException:
             assert has_period_extension
+
+    with pytest.raises(ValueError, match=" is not a positive number"):
+        reduce_and_avg(atoms, repeat, tol=-1)
 
 
 def test_fit_voigt_tensor_to_cell_and_space_group():


### PR DESCRIPTION
Change `reduce_and_avg` to check the tolerance of distances of each atom in the supercell vs. the averaged position in the reduced unit cell, as opposed to checking all pairwise distances within the point cloud that will be averaged into each atom in the reduced unit cell. This is faster and has the effect of roughly doubling the effective tolerance. Roughly, this change makes it so that instead of measuring the diameter of the point cloud that will be averaged into the reduced position, the radius is now measured. This is desirable given the categories of `reduce_and_avg` failures that I've observed. The MD simulation results that failed the tolerance had their distances fall into the following categories:

1) ~NN distance, these are diffusion hops between sites. These should barely be affected by the change, as it is usually only one periodic image that hops, so the reduced position will be little affected. These violations will safely remain on the order of ~100\*tol
2) The A2B_hP9_189_fg_ad FeP EAM period-extension diffusionless phase transition. This one was ~0.06\*NN distance. With the new way of computing distances, it becomes ~0.03\*NN distance, still safely beyond the 0.01\*NN distance default tolerance.
3) A number of very small violations greater than 0.01\*NN distance, but less than 0.02*NN distance. These were able to be reliably reduced to below 0.01\*NN distance by increasing the equilibration time, but this significantly increased the computational cost of the simulations. With the new way of computing distances, these now fall within 0.01\*NN distance even with a shorter equilibration.